### PR TITLE
Update to the new version of cmu_auth and add a catch for FCE parse errors

### DIFF
--- a/cmu_course_api/aggregate.py
+++ b/cmu_course_api/aggregate.py
@@ -54,5 +54,9 @@ def aggregate(descs, schedules, fces):
 def get_course_data(semester, username, password):
     descs = parse_descs(SOURCES)
     schedules = parse_schedules(semester)
-    fces = parse_fces(username, password)
+    try:
+        fces = parse_fces(username, password)
+    except Exception:
+        fces = []
+        print ("Something went wrong. Running without FCEs for now...")
     return aggregate(descs, schedules, fces)

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@
 from setuptools import setup
 
 setup(name='cmu-course-api',
-      version='0.1.4',
+      version='0.1.5',
       description=('Python utility for retrieving information about courses at'
                    ' Carnegie Mellon University.'),
       url='http://scottylabs.org/course-api',

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@
 from setuptools import setup
 
 setup(name='cmu-course-api',
-      version='0.1.3',
+      version='0.1.4',
       description=('Python utility for retrieving information about courses at'
                    ' Carnegie Mellon University.'),
       url='http://scottylabs.org/course-api',
@@ -18,6 +18,6 @@ setup(name='cmu-course-api',
       package_data={'cmu_course_api': ['data/*']},
       install_requires=[
         'beautifulsoup4==4.4.1',
-        'cmu_auth==0.1.6'
+        'cmu_auth==0.1.7'
       ],
       scripts=['bin/cmu-course-api'])


### PR DESCRIPTION
There are still issues with FCE parsing, but this will give a temporary fix so that the other parts of the API can still be used.