### PR TITLE
Courses now always referred to by strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,16 +57,16 @@ Scraped data is output in the following form:
 {
     "courses": {
         ...,
-        "15122": {
+        "15-122": {
             "name": "Principles of Imperative Computation",
             "department": "Computer Science",
             "units": 10.0,
             "semester": ["F", "S"],
             "desc": "For students with a basic understanding of programming...",
             "prereqs": "15-112",
-            "prereqs_obj": {"invert": false, "reqs_list": [[15112]] },
+            "prereqs_obj": {"invert": false, "reqs_list": [["15-112"]] },
             "coreqs": "15-151 and 21-127",
-            "coreqs_obj": {"invert": false, "reqs_list": [[21127],[15151]] },
+            "coreqs_obj": {"invert": false, "reqs_list": [["21-127"],["15-151"]] },
             "lectures": <Meeting object>,
             "sections": <Meeting object>
         },
@@ -101,7 +101,7 @@ fields of the corresponding object will be null.
 Field       | Type       | Description
 ------------|------------|------------
 invert      | Boolean    | Boolean that indicates whether the reqs_list logic is inverted or not.
-reqs_list   | [[int]]    | 2-dimensional list representation of prerequisites/corequisites
+reqs_list   | [[String]] | 2-dimensional list representation of prerequisites/corequisites
 
 In most cases, courses will have requisites with the invert field equal to false, this will be the primary representation. Under the primary representation, the elements
 inside the inner lists operate under 'or' logic while the inner lists with respect to other inner lists operate under 'and' logic. If the invert field is true then the
@@ -135,9 +135,9 @@ primary representation is reversed.
 
 ###### Examples:
 
-{"invert": false, "reqs_list": [ [ 15213, 18243 ], [ 18370, 18396 ] ] } => "(15-213 or 18-243) and (18-370 or 18-396)"
+{"invert": false, "reqs_list": [ [ "15-213", "18-243" ], [ "18-370", "18-396" ] ] } => "(15-213 or 18-243) and (18-370 or 18-396)"
 
-{"invert": true,"reqs_list": [ [ 18320, 18300 ], [ 18402 ] ] }          => "(18-320 and 18-300) or 18-402"
+{"invert": true,"reqs_list": [ [ "18-320", "18-300" ], [ "18-402" ] ] }          => "(18-320 and 18-300) or 18-402"
 
 ### FCEs
 
@@ -149,7 +149,7 @@ Output data is formatted as a list of sections, each with their own statistics:
 [
     ...,
     {
-        "Course ID": 12671,
+        "Course ID": "12-671",
         "Course Name": "FND CONCPT COMP CEE",
         "Dept": "CEE",
         "Enrollment": 7,

--- a/cmu_course_api/aggregate.py
+++ b/cmu_course_api/aggregate.py
@@ -31,7 +31,7 @@ def aggregate(descs, schedules, fces):
     for department in schedules:
         for course in department['courses']:
             for desc in descs:
-                if ('num' in desc and desc['num'] == int(course['num'])):
+                if ('num' in desc and desc['num'] == course['num']):
                     desc['department'] = department['department']
                     desc['lectures'] = course['lectures']
                     desc['sections'] = course['sections']
@@ -39,7 +39,7 @@ def aggregate(descs, schedules, fces):
                     num = desc['num']
                     del desc['num']
 
-                    courses[str(num)] = desc
+                    courses[num] = desc
 
     return {'courses': courses, 'fces': fces}
 

--- a/cmu_course_api/parse_descs.py
+++ b/cmu_course_api/parse_descs.py
@@ -15,11 +15,10 @@ import bs4
 # @brief Extracts the course number and name from a dt element from a
 #        course description webpage.
 # @param dtelement: <dt> element from a course description webpage.
-# @return (num (int), name (string)): The course number and name.
+# @return (num (string), name (string)): The course number and name.
 def extract_num_name(dtelement):
     elements = dtelement.get_text().split(' ', 1)
-    num = int(re.sub('\D', '', elements[0]))
-    return (num, elements[1])
+    return (elements[0], elements[1])
 
 
 # @function extract_units_semester_info
@@ -107,8 +106,7 @@ def create_reqs_list(reqs, conj):
 
         for course in courses:
             formatted_str = course.strip()
-            course_num = int(re.sub('\D', '', formatted_str))
-            inner_list.append(course_num)
+            inner_list.append(formatted_str)
 
         reqs_list.append(inner_list)
 

--- a/cmu_course_api/parse_fces.py
+++ b/cmu_course_api/parse_fces.py
@@ -147,7 +147,10 @@ def parse_table(table):
 
                 if index < question_start:
                     if cell.data['ss:type'] == 'Number' and value:
-                        value = int(value)
+                        if columns[index] == 'Course ID':
+                            value = value[:2] + '-' + value[2:]
+                        else:
+                            value = int(value)
                     obj[columns[index]] = value
                 else:
                     if value:

--- a/cmu_course_api/parse_schedules.py
+++ b/cmu_course_api/parse_schedules.py
@@ -229,7 +229,7 @@ def parse_row(row):
         # case course (determined by having a numeric course)
         elif row[0] and row[0].isdigit():
             data = {}
-            data['num'] = row[0]
+            data['num'] = row[0][:2] + '-' + row[0][2:]
             data['title'] = row[1]
             data['units'] = row[2]
             data['lectures'] = [parse_lec_sec(row)]

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@
 from setuptools import setup
 
 setup(name='cmu-course-api',
-      version='1.0.0',
+      version='1.1.0',
       description=('Python utility for retrieving information about courses at'
                    ' Carnegie Mellon University.'),
       url='http://scottylabs.org/course-api',


### PR DESCRIPTION
JSON dictionaries don't support integers as keys, so for consistency courses are now only referred to by their number in a string, **with dashes**. This should make it easy to users to cross reference different fields (ex, FCEs with descriptions).

Resolves #34 