### PR TITLE
Separated FCE parser into its own script, and removed FCE downloading feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ The Scottylabs Course API is now available as a pip package! All you need to do 
 $ pip3 install cmu-course-api
 ```
 
-## Usage
+## Course Schedules & Descriptions Usage
 
-To use from the command line, run:
+To get course schedules and descriptions from the command line, run:
 
 ```
 $ cmu-course-api [SEMESTER] [OUTFILE]
@@ -36,6 +36,34 @@ data = cmu_course_api.get_course_data(semester)
 
 Then, `data` will contain the course information as a Python object.
 
+See [Course output format][#course-output-format] for details.
+
+## FCEs Usage
+
+To parse FCE data, download the relevant data set from the [CMU FCE website](https://cmu.smartevals.com) by logging in, clicking "See Results from Past Years", then the Excel icon at the lop left of the table. Make sure to choose CSV format. Place all files at the top level of a folder.
+
+Parse the data by running the following from the command line:
+
+```
+$ cmu-fce-api [FOLDER] [OUTFILE]
+```
+
+`FOLDER` is the folder containing CSV files to parse.
+
+`OUTFILE` is a path to write the output JSON to.
+
+Alternatively, you can use the FCE API in your Python 3 projects:
+
+```python
+import cmu_course_api
+
+fces = cmu_course_api.parse_fces(csvpath)
+```
+
+Then `fces` will contain the FCE data in the file `csvpath`.
+
+See [FCE output format][#fce-output-format] for details.
+
 ## Minification
 
 By default, all output data is stored as a minified JSON file. To get human readable JSON, use the command (for output file `out.json`):
@@ -44,7 +72,7 @@ By default, all output data is stored as a minified JSON file. To get human read
 $ python -m json.tool out.json
 ```
 
-## Output format
+## Course output format
 
 Scraped data is output in the following form:
 
@@ -134,46 +162,6 @@ primary representation is reversed.
 
 {"invert": true,"reqs_list": [ [ "18-320", "18-300" ], [ "18-402" ] ] }          => "(18-320 and 18-300) or 18-402"
 
-### FCEs
-
-Beware that any field below may have `null` instead of the expected value.
-
-Output data is formatted as a list of sections, each with their own statistics:
-
-```
-[
-    ...,
-    {
-        "Course ID": "12-671",
-        "Course Name": "FND CONCPT COMP CEE",
-        "Dept": "CEE",
-        "Enrollment": 7,
-        "Instructor": "FINGER, S.",
-        "Resp. Rate %": "71%",
-        "Responses": 5,
-        "Section": "A3",
-        "Semester": "Spring",
-        "Type": "Lect",
-        "Year": 2015,
-        "Questions": {
-            "1: Hrs Per Week 9": 10.0,
-            "2: Interest in student learning": 4.8,
-            "3: Explain course requirements": 4.4,
-            "4: Clear learning goals": 4.4,
-            "5: Feedback to students": 5.0,
-            "6: Importance of subject": 4.4,
-            "7: Explains subject matter": 4.8,
-            "8: Show respect for students": 5.0,
-            "9: Overall teaching": 4.8
-            "10: Overall course": 4.6,
-        }
-    },
-    ...
-]
-```
-
-All fields are subject to change depending on how CMU's departments decide to structure their FCEs for a given semester. The fields available and their names are very likely to be different between semesters and departments. Please see https://cmu.smartevals.com/ for the exact format. All keys are column names corresponding to their value. Questions (columns starting with a number) are sorted into their own "Questions" field, with the question as the key and the result as a float value.
-
 ### Meetings
 
 A meeting has the form:
@@ -220,6 +208,47 @@ end      | String   | The time at which the lecture or section ends. This field 
 location | String   | The location of the lecture or section's meeting. Probably Pittsburgh, Pennsylvania or Doha, Qatar.
 building | String   | The building in which the lecture or section meets. Null if the meeting location is TBA.
 room     | String   | The room in which the meeting is held. Null if the meeting location is TBA.
+
+## FCE output format
+
+Beware that any field below may have `null` instead of the expected value.
+
+Output data is formatted as a list of sections, each with their own statistics:
+
+```
+[
+    ...,
+    {
+        "Course ID": "12-671",
+        "Course Name": "FND CONCPT COMP CEE",
+        "Dept": "CEE",
+        "Enrollment": 7,
+        "Instructor": "FINGER, S.",
+        "Resp. Rate %": "71%",
+        "Responses": 5,
+        "Section": "A3",
+        "Semester": "Spring",
+        "Type": "Lect",
+        "Year": 2015,
+        "Questions": {
+            "1: Hrs Per Week 9": 10.0,
+            "2: Interest in student learning": 4.8,
+            "3: Explain course requirements": 4.4,
+            "4: Clear learning goals": 4.4,
+            "5: Feedback to students": 5.0,
+            "6: Importance of subject": 4.4,
+            "7: Explains subject matter": 4.8,
+            "8: Show respect for students": 5.0,
+            "9: Overall teaching": 4.8
+            "10: Overall course": 4.6,
+        }
+    },
+    ...
+]
+```
+
+All fields are subject to change depending on how CMU's departments decide to structure their FCEs for a given semester. The fields available and their names are very likely to be different between semesters and departments. Please see https://cmu.smartevals.com/ for the exact format. All keys are column names corresponding to their value. Questions (columns starting with a number) are sorted into their own "Questions" field, with the question as the key and the result as a float value.
+
 
 ## Submitting New Versions
 

--- a/README.md
+++ b/README.md
@@ -20,23 +20,18 @@ To use from the command line, run:
 
 ```
 $ cmu-course-api [SEMESTER] [OUTFILE]
-$ cmu-course-api [SEMESTER] [OUTFILE] <USERNAME> <PASSWORD>
 ```
 
 `SEMESTER` is the school semester for which you wish to retrieve scheduling data. It must be one of S, M1, M2, or F.
 
 `OUTFILE` is a path to write the output JSON to.
 
-`USERNAME` is the Andrew username used for authentication. If not specified, you will be prompted to input one.
-
-`PASSWORD` is the Andrew password used for authentication. If not specified, you will be prompted to input one.
-
 Alternatively, you can use the course API in your Python 3 projects:
 
 ```python
 import cmu_course_api
 
-data = cmu_course_api.get_course_data(semester, username, password)
+data = cmu_course_api.get_course_data(semester)
 ```
 
 Then, `data` will contain the course information as a Python object.
@@ -70,8 +65,7 @@ Scraped data is output in the following form:
             "sections": <Meeting object>
         },
         ...
-    }
-    "fces": <FCEs object>,
+    },
     "rundate": "2016-05-27",
     "semester": "Spring 2016"
 }
@@ -90,7 +84,6 @@ coreqs     | String     | Course corequisites as a string
 coreqs_obj | Object     | Course corequisites as an object representation
 lectures   | {}         | Lectures for this semester. See the [Meetings section](#meetings) for more info.
 sections   | {}         | Sections for this semester. See the [Meetings section](#meetings) for more info.
-fces       | {}         | All historical FCEs, organized by section. See the [FCEs section](#fces) for more info.
 rundate    | String     | Date that this JSON blob was generated in ISO format (YYYY-MM-DD).
 semester   | String     | Semester that this data's schedules represent.
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ data = cmu_course_api.get_course_data(semester)
 
 Then, `data` will contain the course information as a Python object.
 
-See [Course output format][#course-output-format] for details.
+See [Course output format](#course-output-format) for details.
 
 ## FCEs Usage
 
@@ -62,7 +62,7 @@ fces = cmu_course_api.parse_fces(csvpath)
 
 Then `fces` will contain the FCE data in the file `csvpath`.
 
-See [FCE output format][#fce-output-format] for details.
+See [FCE output format](#fce-output-format) for details.
 
 ## Minification
 

--- a/bin/cmu-course-api
+++ b/bin/cmu-course-api
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
 # @file cmu-course-api
 # @brief Downloads schedule data for a specific semester, including course
-#        meeting times, course descriptions, pre/corequisites, FCEs, and so on.
+#        meeting times, course descriptions, pre/corequisites, and so on.
 #        Output is parsed into a single JSON output file.
 #
-#        USAGE: cmu-course-api [SEMESTER] [OUTFILE] <USERNAME PASSWORD>
+#        USAGE: cmu-course-api [SEMESTER] [OUTFILE]
 #
 # @author Justin Gallagher (jrgallag@andrew.cmu.edu)
 # @since 2015-11-08
@@ -13,15 +13,14 @@
 import cmu_course_api
 import json
 import sys
-import getpass
 
 
 # Constants
-USAGE = 'USAGE: cmu-course-api [SEMESTER] [OUTFILE] <USERNAME PASSWORD>'
+USAGE = 'USAGE: cmu-course-api [SEMESTER] [OUTFILE]'
 
 
 # Verify arguments
-if not (len(sys.argv) == 5 or len(sys.argv) == 3):
+if not (len(sys.argv) == 3):
     print(USAGE)
     sys.exit()
 
@@ -32,20 +31,11 @@ if semester not in ['S', 'M1', 'M2', 'F']:
     print("Requested quarter is not one of ['S', 'M1', 'M2', 'F']")
     sys.exit()
 
-if (len(sys.argv) == 3):
-    print('Please input your Andrew username and password. '
-          'We never store your login info.')
-    username = input('Username: ')
-    password = getpass.getpass()
-else:
-    username = sys.argv[3]
-    password = sys.argv[4]
-
 # Get the data
 print('Scottylabs CMU Course-API')
 
 print('Getting data...')
-data = cmu_course_api.get_course_data(semester, username, password)
+data = cmu_course_api.get_course_data(semester)
 
 print('Writing data...')
 with open(outpath, 'w') as outfile:

--- a/bin/cmu-fce-api
+++ b/bin/cmu-fce-api
@@ -31,7 +31,7 @@ folder = sys.argv[1]
 outpath = sys.argv[2]
 
 # Get list of files to process
-files = [f for f in listdir(folder) if isfile(join(folder, f))]
+files = [join(folder, f) for f in listdir(folder) if isfile(join(folder, f))]
 
 # Get data
 print('Scottylabs CMU Course-API')
@@ -39,7 +39,11 @@ print('Parsing FCE information...')
 data = []
 
 for csv in files:
+    print('\tProcessing ' + str(csv) + '...')
     data.append(cmu_course_api.parse_fces(csv))
+
+# Flatten the list
+data = [item for lst in data for item in lst]
 
 print('Writing data...')
 with open(outpath, 'w') as outfile:

--- a/bin/cmu-fce-api
+++ b/bin/cmu-fce-api
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+# @file cmu-fce-api
+# @brief Parses downloaded FCE data CSVs into JSON.
+#
+#        Data should be downloaded from cmu.smartevals.com as CSV, and placed
+#        in the top level of the passed folder.
+#
+#        USAGE: cmu-fce-api [FCE FOLDER] [OUTFILE]
+#
+# @author Justin Gallagher (jrgallag@andrew.cmu.edu)
+# @since 2016-07-11
+
+
+import cmu_course_api
+import json
+import sys
+from os import listdir
+from os.path import isfile, join
+
+
+# Constants
+USAGE = 'USAGE: cmu-fce-api [FCE FOLDER] [OUTFILE]'
+
+
+# Verify arguments
+if not (len(sys.argv) == 3):
+    print(USAGE)
+    sys.exit()
+
+folder = sys.argv[1]
+outpath = sys.argv[2]
+
+# Get list of files to process
+files = [f for f in listdir(folder) if isfile(join(folder, f))]
+
+# Get data
+print('Scottylabs CMU Course-API')
+print('Parsing FCE information...')
+data = []
+
+for csv in files:
+    data.append(cmu_course_api.parse_fces(csv))
+
+print('Writing data...')
+with open(outpath, 'w') as outfile:
+    json.dump(data, outfile)
+
+print('Done!')

--- a/cmu_course_api/__init__.py
+++ b/cmu_course_api/__init__.py
@@ -5,3 +5,4 @@
 
 
 from .aggregate import get_course_data
+from .parse_fces import parse_fces

--- a/cmu_course_api/aggregate.py
+++ b/cmu_course_api/aggregate.py
@@ -11,7 +11,6 @@ import os.path
 from datetime import date
 from cmu_course_api.parse_descs import get_course_desc
 from cmu_course_api.parse_schedules import parse_schedules
-from cmu_course_api.parse_fces import parse_fces
 
 # imports used for multithreading
 import threading
@@ -30,12 +29,10 @@ SEMESTER_ABBREV = {
 
 
 # @function aggregate
-# @brief Combines the course descriptions, schedules, and FCEs data sets into
-#        one object.
+# @brief Combines the course descriptions and schedules into one object.
 # @param schedules: Course schedules object as returned by parse_descs.
-# @param fces: FCEs object as returned by parse_descs.
 # @return An object containing the aggregate of the three datasets.
-def aggregate(schedules, fces):
+def aggregate(schedules):
     courses = {}
 
     semester = schedules['semester'].split(' ')[0]
@@ -92,7 +89,7 @@ def aggregate(schedules, fces):
 
     queue.join()
 
-    return {'courses': courses, 'fces': fces, 'rundate': str(date.today()),
+    return {'courses': courses, 'rundate': str(date.today()),
             'semester': schedules['semester']}
 
 
@@ -100,15 +97,8 @@ def aggregate(schedules, fces):
 # @brief Used for retrieving all information from the course-api for a given
 #        semester.
 # @param semester: The semester to get data for. Must be one of [S, M1, M2, F].
-# @param username: Username to use for andrew authentication.
-# @param password: Password to use for andrew authentication.
 # @return Object containing all course-api data - see README.md for more
 #        information.
-def get_course_data(semester, username, password):
+def get_course_data(semester):
     schedules = parse_schedules(semester)
-    try:
-        fces = parse_fces(username, password)
-    except Exception:
-        fces = []
-        print('Something went wrong. Running without FCEs for now...')
-    return aggregate(schedules, fces)
+    return aggregate(schedules)

--- a/cmu_course_api/parse_fces.py
+++ b/cmu_course_api/parse_fces.py
@@ -8,183 +8,30 @@
 # @author Justin Gallagher (jrgallag@andrew.cmu.edu)
 # @since 2015-01-22
 
-import bs4
-import copy
-import cmu_auth
-import urllib.parse
-import requests
 
-
-# Constants
-USAGE = 'Usage: python parse_fces.py [OUTFILE] <USERNAME PASSWORD>'
-LOGIN_URL = 'https://cmu.smartevals.com/secure/Login.aspx'
-SOURCE_URL = 'https://student.smartevals.com/reporting/SurveyResults.aspx'
-URL_PARAMS = {
-    'xp': 't',
-    'hg': 't',
-    'dep': 'all',
-    't': 'all',
-    'lvty': 'all/all/all',
-    'st': 'meantext',
-    'sat': 'all',
-    'cat': 'all',
-    'q': 'all',
-    'y': 'all',
-    'gb': 'CourseID',
-    'b': 'all',
-    'c': 'all',
-    'cg': 'all',
-    'u': 'all',
-    'ds': 'normal',
-    'srfall': 'Y'
-}
-DIVS = [683, 693, 685, 691, 684, 687, 690, 2369, 733]
-SESSION_ID_COOKIE = "ASP.NET_SessionId"
-
-
-# Request form data
-formdata = {
-    '_ctl0:cphContent:rddset:sfexporter:drp_FileType': 'msoXML',
-    '_ctl0:cphContent:rddset:sfexporter:chk_Defaults': 'on',
-    '_ctl0:cphContent:rddset:sfexporter:chk_ShowColumnTitles': 'on',
-    '_ctl0:cphContent:rddset:sfexporter:btnSubmit': 'Export',
-    '_ctl0:chkColumns_0': 'on',
-    '_ctl0:chkColumns_1': 'on',
-    '_ctl0:chkColumns_2': 'on',
-    '_ctl0:chkColumns_5': 'on',
-    '_ctl0:chkColumns_6': 'on',
-    '_ctl0:chkColumns_7': 'on',
-    '_ctl0:chkColumns_8': 'on',
-    '_ctl0:chkColumns_9': 'on',
-}
-
-
-# @function authenticate
-# @brief Gets the authenication token that needs to be included to query FCE
-#        data.
-# @param username: Andrew username to use for authentication.
-# @param password: Andrew password to use for authentication.
-# @return The ASP.NET session cookie that must be set in requests.
-def authenticate(username, password):
-    # Login
-    s = cmu_auth.authenticate(LOGIN_URL, username, password)
-    login_page = s.get(LOGIN_URL)
-    soup = bs4.BeautifulSoup(login_page.text, 'html.parser')
-
-    # Parse needed authenication token
-    login_link = soup.find('a', {'id': 'HyperLink1'})['href']
-    login_link_queries = urllib.parse.urlparse(login_link)[4]
-    hdnPersonAuth = urllib.parse.parse_qs(login_link_queries)['a2e'][0]
-
-    # Add auth token to the form submission
-    formdata['_ctl0:hdnPersonAuth'] = hdnPersonAuth
-    return s.cookies[SESSION_ID_COOKIE]
-
-
-# @function download_fces
-# @brief Downloads FCE data from the smartevals website as MSXML.
-# @param div: The smartevals website divides departments into 'div''s seemingly
-#        arbitrarily, each one having a code.
-# @param username: Andrew username to use for authentication.
-# @param password: Andrew password to use for authentication.
-# @param sessionid: Session ID cookie to use.
-# @return: Raw text for the MSXML file for this division's FCE data
-def download_fces(div, username, password, sessionid):
-    # Create target URL
-    parameters = copy.copy(URL_PARAMS)
-    parameters['div'] = div
-    url = SOURCE_URL + '?' + urllib.parse.urlencode(parameters)
-
-    # Build cookies
-    cookies = {
-        SESSION_ID_COOKIE: sessionid
-    }
-
-    # Get viewstate
-    s = requests.Session()
-    export_page = s.get(url, cookies=cookies, data=formdata).content
-    soup = bs4.BeautifulSoup(export_page, 'html.parser')
-    viewstate = soup.find('input', {'id': '__VIEWSTATE'})['value']
-    formdata['__VIEWSTATE'] = viewstate
-
-    # Download output MSXML
-    pst2 = s.post(url, cookies=cookies, data=formdata)
-    return pst2.text
-
-
-# @function parse_table
-# @brief Parses FCE data from a BeautifulSoup XML table object.
-# @param table: Table object from an FCE XML file.
-# @return [{}]: Array of data which represents FCE data by section.
-def parse_table(table):
-    rows = table.find_all('row')
-    columns = []
-    result = []
-    question_start = 0
-
-    for row in rows:
-        cells = row.find_all('cell')
-        if len(cells) > 0 and cells[0].string == 'Semester':
-            # Columns are not consistent in a table - update them when
-            # new labels are found.
-            columns = [lbl.string.strip() for lbl in row if lbl.string.strip()]
-            question_start = next((i for i, col in enumerate(columns)
-                                   if col[0].isdigit()), len(columns))
-        else:
-            # Remove empty cells
-            cells = cells[:len(columns)]
-
-            # Build object to represent this section
-            obj = {}
-            questions = {}
-            for index, cell in enumerate(cells):
-                # Parse cell value
-                value = cell.string
-                if not value:
-                    continue
-
-                value = value.strip()
-
-                if index < question_start:
-                    if cell.data['ss:type'] == 'Number' and value:
-                        if columns[index] == 'Course ID':
-                            value = value[:2] + '-' + value[2:]
-                        else:
-                            value = int(value)
-                    obj[columns[index]] = value
-                else:
-                    if value:
-                        value = float(value)
-                    questions[columns[index]] = value
-
-            obj['Questions'] = questions
-            result.append(obj)
-
-    return result
+import csv
 
 
 # @function parse_fces
-# @brief Downloads and parses FCE data to JSON.
-# @param username: Andrew username to use for authentication.
-# @param password: Andrew password to use for authentication.
-# @return: FCE data for all departments and years as JSON.
-def parse_fces(username, password):
-    data = []
+# @brief Parses FCE data from a CSV file to JSON.
+# @param path: File location of CSV to parse from.
+# @return: FCE data as JSON.
+def parse_fces(path):
 
-    # Authenticate
-    print('Authenticating...')
-    sessionid = authenticate(username, password)
+    results = []
 
-    # Iterate through all colleges
-    for div in DIVS:
-        # Download FCE data
-        print('Downloading data for div ' + str(div) + '...')
-        downloaded = download_fces(div, username, password, sessionid)
-
-        # Parse data into dictionary
-        print('Parsing...')
-        soup = bs4.BeautifulSoup(downloaded, 'html.parser')
-        data += parse_table(soup.find('table'))
+    # Iterate through lines of CSV
+    categories = []
+    with open(path, 'r') as f:
+        for line in csv.reader(f):
+            if line[0] == 'Semester':
+                categories = line
+            else:
+                entry = {}
+                for cat in range(len(categories)):
+                    if categories[cat] != '':
+                        entry[categories[cat]] = line[cat]
+                results.append(entry)
 
     # Return as JSON
-    return data
+    return results

--- a/cmu_course_api/parse_fces.py
+++ b/cmu_course_api/parse_fces.py
@@ -19,19 +19,45 @@ import csv
 def parse_fces(path):
 
     results = []
+    categories = []
 
     # Iterate through lines of CSV
-    categories = []
     with open(path, 'r') as f:
         for line in csv.reader(f):
+
+            # If this row specifies new column tags, update our categories
             if line[0] == 'Semester':
                 categories = line
-            else:
-                entry = {}
-                for cat in range(len(categories)):
-                    if categories[cat] != '':
-                        entry[categories[cat]] = line[cat]
-                results.append(entry)
+                continue
+
+            entry = {}
+            entry['Questions'] = {}
+
+            for cat in range(len(categories)):
+
+                # Set null if no data supplied
+                if line[cat] == '':
+                    line[cat] = None
+
+                # Skip unused columns
+                if categories[cat] == '':
+                    continue
+
+                # Ensure course IDs have the proper format (##-###)
+                if categories[cat] == 'Course ID' and line[cat] != None:
+                    num = line[cat]
+                    if len(num) == 4:
+                        num = '0' + num
+                    entry[categories[cat]] = num[:2] + '-' + num[2:]
+
+                # If a category starts with a number, file it as a question
+                elif categories[cat][0].isdigit():
+                    entry['Questions'][categories[cat]] = line[cat]
+
+                else:
+                    entry[categories[cat]] = line[cat]
+
+            results.append(entry)
 
     # Return as JSON
     return results

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,6 @@ setup(name='cmu-course-api',
       license='MIT',
       packages=['cmu_course_api'],
       install_requires=[
-        'beautifulsoup4==4.4.1',
-        'cmu_auth==0.1.7'
+        'beautifulsoup4==4.4.1'
       ],
       scripts=['bin/cmu-course-api', 'bin/cmu-fce-api'])

--- a/setup.py
+++ b/setup.py
@@ -15,9 +15,8 @@ setup(name='cmu-course-api',
       author_email='info@scottylabs.org',
       license='MIT',
       packages=['cmu_course_api'],
-      package_data={'cmu_course_api': ['data/*']},
       install_requires=[
         'beautifulsoup4==4.4.1',
         'cmu_auth==0.1.7'
       ],
-      scripts=['bin/cmu-course-api'])
+      scripts=['bin/cmu-course-api', 'bin/cmu-fce-api'])


### PR DESCRIPTION
It doesn't make much sense to combine the FCE data and the schedule data (mostly because FCEs aren't tied to the current semester), so I've split the two into separate scripts.

The `cmu-course-api` downloads course schedules & descriptions for a specific semester.

The `cmu-fce-api` parses FCE data. As downloading directly from the FCE website isn't working currently, I've retooled this script to work on locally downloaded files. Users will need to download the CSV data manually.

Because the script works on local files, authentication is no longer necessary and has been removed.

Hopefully, auto-downloading for FCEs can be re-added in the future.