### PR TITLE
import sys

### DIFF
--- a/cmu_course_api/parse_schedules.py
+++ b/cmu_course_api/parse_schedules.py
@@ -39,7 +39,7 @@ lettered lecture and comprise much of this category of courses.
 
 import urllib.request
 import bs4
-
+import sys
 
 def get_page(quarter):
     '''


### PR DESCRIPTION
Missing import caused the program to throw a name error instead of exiting as intended upon calling `sys.exit()`. Fixed by adding missing import.