### PR TITLE
Implement more useful printing of information

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@
 from setuptools import setup
 
 setup(name='cmu-course-api',
-      version='1.5.2',
+      version='1.5.3',
       description=('Python utility for retrieving information about courses at'
                    ' Carnegie Mellon University.'),
       url='http://scottylabs.org/course-api',


### PR DESCRIPTION
This commit prints the current course being processed and the total number of courses to be processes, then replaces the line with the sequential course, so that there aren’t thousands of lines printed out.

The following demonstrates what it looks like (note that `test.py` is the same as `cmu-course-api`).

![Example](https://user-images.githubusercontent.com/29032680/54146094-3ff02380-43fd-11e9-9c55-98989771d648.gif)

And as a second note, I changed the version number; someone with access to PyPI would need to update the package.